### PR TITLE
PhraseLoader update

### DIFF
--- a/functions/loaders/PhraseappLoader.js
+++ b/functions/loaders/PhraseappLoader.js
@@ -58,7 +58,7 @@ module.exports = (projectId, token) => {
             }
           })
       }),
-      { concurrency: 2 },
+      { concurrency: 4 },
     )
     // [
     //   {


### PR DESCRIPTION
Phrase API now supports 4 concurrent (parallel) requests